### PR TITLE
Bug fix for a rare edge case

### DIFF
--- a/scripts/decode_database.py
+++ b/scripts/decode_database.py
@@ -38,7 +38,6 @@ def hex_to_offtargetinfo(hexstr, delim):
 def map_int_to_coord(x, genome, onebased=False):
     strand = '+' if x > 0 else '-'
     x = abs(x)
-    x -= 1
     i = 0
     while genome[i]['LN'] <= x:
         x -= genome[i]['LN']
@@ -52,11 +51,11 @@ def map_int_to_coord(x, genome, onebased=False):
 
 def map_coord_to_sequence(fasta_record_dict, sgrna, chr, pos, strand):
     if strand == '+':
-        pos_start = pos + 2 - len(sgrna)
-        pos_end = pos + 2
+        pos_start = pos + 1 - len(sgrna)
+        pos_end = pos + 1
     else:
-        pos_start = pos + 1
-        pos_end = pos + 1 + len(sgrna)
+        pos_start = pos
+        pos_end = pos + len(sgrna)
     return fasta_record_dict[chr].seq[pos_start:pos_end].upper()
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
We're decrementing the off-target position by 1 (for reasons I don't understand), in *all* cases, in the `map_int_to_coord` function, only to compensate for it later by adding `2` instead of `1` (again in all cases) when we use its output in the `map_coord_to_sequence` function.

While both these in conjunction have the same effect as not decrementing at all, and incrementing by 1 instead of 2 later (which feels natural and is what the upcoming PR for these calculations in C++ will do), it does affect the very rare case (3 cases out of ~5M for `ce11`) where the off-target match is exactly at the start of the chromosome, in which case the `map_int_to_coord` function ends up reporting the chromosome that is before where the off-target actually lies, and subsequent code in the script throws away the off-target as invalid (because it determines that its not 23 BPs long after all).

There is no other place where the `pos` output of `map_int_to_coord` is used other than `map_coord_to_sequence`, so this has no side effects. I've run the script before/after on the sam file for `ce11` and it produces exactly the same output, except for the 3 cases that it fixes.

While not a big deal practically, this PR will reduce the confusion around the `-1` and `+2`, so I think it's worthwhile.