### PR TITLE
Download command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(guidescan-cli)
 
 set(PROJECT_VERSION VERSION 2.0)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 set(GUIDESCAN_VERSION "2.0.0" CACHE STRING "The version number of GuideScan")

--- a/include/genomics/printer.hpp
+++ b/include/genomics/printer.hpp
@@ -96,6 +96,8 @@ namespace genomics {
     }
 
     float calculate_cfd(std::string sgRNA, std::string sequence, std::string PAM) {
+      if (PAM.length() != 3) return 1.0; // CFD only defined for length 3 PAMs.
+
       float cfd = 1.0;
       for (int i=0; i<sgRNA.length(); i++) {
         char _sgRNA = sgRNA.at(i);
@@ -220,6 +222,7 @@ namespace genomics {
     std::string csvlines;
 
     float cfd_sum = 0.0;
+    bool perfect_match = false;
     std::vector<std::string> off_targets_lines;
     for (uint64_t d = 0; d < off_targets.size(); d++) {
       for (int64_t i = 0; i < off_targets[d].size(); i++) {
@@ -227,6 +230,7 @@ namespace genomics {
         const auto& off_target = off_targets[d][i];
         int64_t off_target_abs_coords = std::get<0>(off_target);
         match match = std::get<1>(off_target);
+        perfect_match = match.mismatches == 0;
         std::string csvline = get_csv_line(gi, k, start, match, off_target_abs_coords, complete);
         if (csvline != "") {
           off_targets_lines.push_back(csvline);
@@ -237,7 +241,11 @@ namespace genomics {
 
     // Each off-target will have the same specificity value - add at the end of each line
     float specificity = 0.0;
+    if (!perfect_match) cfd_sum += 1;
     if (cfd_sum > 0) specificity = 1/cfd_sum;
+    if ((specificity < 0) || (specificity > 1)) {
+      throw std::invalid_argument("nooo");
+    }
     for (auto line: off_targets_lines) {
       csvlines += line + "," + std::to_string(specificity) + "\n";
     }

--- a/include/genomics/printer.hpp
+++ b/include/genomics/printer.hpp
@@ -243,9 +243,6 @@ namespace genomics {
     float specificity = 0.0;
     if (!perfect_match) cfd_sum += 1;
     if (cfd_sum > 0) specificity = 1/cfd_sum;
-    if ((specificity < 0) || (specificity > 1)) {
-      throw std::invalid_argument("nooo");
-    }
     for (auto line: off_targets_lines) {
       csvlines += line + "," + std::to_string(specificity) + "\n";
     }

--- a/include/guidescan.hpp
+++ b/include/guidescan.hpp
@@ -53,17 +53,20 @@ struct enumerate_cmd_options {
 };
 
 struct download_cmd_options {
-    std::string api_url;
-    CLI::Option* api_url_opt = nullptr;
+    std::string download_url;
+    CLI::Option* download_url_opt = nullptr;
 
     std::string type;
     CLI::Option* type_opt = nullptr;
 
-    std::string organism;
-    CLI::Option* organism_opt = nullptr;
+    std::string item;
+    CLI::Option* item_opt = nullptr;
 
     std::string output_directory;
     CLI::Option* output_directory_opt = nullptr;
+
+    std::string show;
+    CLI::Option* show_opt = nullptr;
 };
 
 #endif

--- a/include/guidescan.hpp
+++ b/include/guidescan.hpp
@@ -52,4 +52,18 @@ struct enumerate_cmd_options {
   CLI::Option* alt_pams_opt = nullptr;
 };
 
+struct download_cmd_options {
+    std::string api_url;
+    CLI::Option* api_url_opt = nullptr;
+
+    std::string type;
+    CLI::Option* type_opt = nullptr;
+
+    std::string organism;
+    CLI::Option* organism_opt = nullptr;
+
+    std::string output_directory;
+    CLI::Option* output_directory_opt = nullptr;
+};
+
 #endif

--- a/include/io/curl.hpp
+++ b/include/io/curl.hpp
@@ -1,0 +1,8 @@
+#include <json.hpp>
+
+using json = nlohmann::json;
+
+namespace io {
+    int download_file(std::string url, std::string outfilename);
+    json download_json(std::string url);
+}

--- a/include/io/curl.hpp
+++ b/include/io/curl.hpp
@@ -4,5 +4,5 @@ using json = nlohmann::json;
 
 namespace io {
     int download_file(std::string url, std::string outfilename);
-    json download_json(std::string url);
+    int download_json(std::string url, json& json_data);
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,8 @@ add_executable(guidescan guidescan.cxx
   genomics/seq_io.cxx
   genomics/kmer.cxx
   genomics/structures.cxx
-  genomics/sequences.cxx )
+  genomics/sequences.cxx
+  io/curl.cxx)
 
 find_package(CURL REQUIRED)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,13 +4,16 @@ add_executable(guidescan guidescan.cxx
   genomics/structures.cxx
   genomics/sequences.cxx )
 
+find_package(CURL REQUIRED)
+
 target_include_directories(guidescan PUBLIC 
   "${CMAKE_SOURCE_DIR}/include"
   "${PROJECT_BINARY_DIR}/sdsl/include"
-  "${PROJECT_BINARY_DIR}/sdsl/external/libdivsufsort/include")
+  "${PROJECT_BINARY_DIR}/sdsl/external/libdivsufsort/include"
+  "${CURL_INCLUDE_DIR}")
 
 # What if pthread isn't found? Find alternatives...
-target_link_libraries(guidescan PUBLIC sdsl divsufsort divsufsort64 pthread)
+target_link_libraries(guidescan PUBLIC sdsl divsufsort divsufsort64 pthread ${CURL_LIBRARIES})
 
 # Static linking trick comes from here:
 # https://stackoverflow.com/questions/35116327/when-g-static-link-pthread-cause-segmentation-fault-why

--- a/src/guidescan.cxx
+++ b/src/guidescan.cxx
@@ -78,7 +78,7 @@ CLI::App* enumerate_cmd(CLI::App &guidescan, enumerate_cmd_options& opts) {
 CLI::App* download_cmd(CLI::App &guidescan, download_cmd_options& opts) {
   auto build  = guidescan.add_subcommand("download", "Downloads GuideScan data over HTTP.");
 
-  opts.download_url = "http://localhost:8000/download";
+  opts.download_url = "http://guidescan.com:8000/download";
   opts.type = "";
   opts.item = "";
   opts.output_directory = ".";

--- a/src/guidescan.cxx
+++ b/src/guidescan.cxx
@@ -268,7 +268,7 @@ int do_download_cmd(const download_cmd_options& opts) {
     for (auto& [key, value] : json_doc.items()) {
       msg += " " + key;
     }
-    std::cout << "Supported types are:" + msg;
+    std::cout << "Supported types are:" + msg << std::endl;
     return 0;
   } else if (opts.show == "item") {
     if (opts.type == "") {

--- a/src/guidescan.cxx
+++ b/src/guidescan.cxx
@@ -307,7 +307,7 @@ int do_download_cmd(const download_cmd_options& opts) {
       return 1;
     }
   } else {
-    std::cout << "Unrecognized type. Specify the type using --type or use \"--show type\" to see available items." << std::endl;
+    std::cout << "Unrecognized type. Specify the type using --type or use \"--show type\" to see available types." << std::endl;
     return 1;
   }
   return 0;

--- a/src/io/curl.cxx
+++ b/src/io/curl.cxx
@@ -1,0 +1,77 @@
+#include <curl/curl.h>
+#include <json.hpp>
+
+#include "guidescan.hpp"
+#include "io/curl.hpp"
+
+using json = nlohmann::json;
+using path = std::filesystem::path;
+
+
+namespace io {
+    size_t write_stream(void *ptr, size_t size, size_t nmemb, std::ofstream *stream) {
+      stream->write((char*)ptr, size * nmemb);
+      return size * nmemb;
+    }
+
+    size_t write_string(void *ptr, size_t size, size_t nmemb, std::string *data) {
+      data->append((char*)ptr, size * nmemb);
+      return size * nmemb;
+    }
+
+    int progress_callback(void* clientp, double dltotal, double dlnow, double ultotal, double ulnow)
+    {
+      if (dltotal <= 0) return 0;
+      printf("Downloading %3.0f%\r", dlnow / dltotal * 100);
+      fflush(stdout);
+      return 0;
+    }
+
+    int download_file(std::string url, std::string outfilename) {
+
+      CURL *curl;
+      CURLcode res;
+      std::ofstream outfile;
+
+      curl = curl_easy_init();
+      if (curl) {
+        outfile.open(outfilename, std::ios::binary);
+
+        curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_stream);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &outfile);
+        curl_easy_setopt(curl, CURLOPT_NOPROGRESS, false);
+        curl_easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, progress_callback);
+
+        res = curl_easy_perform(curl);
+        curl_easy_cleanup(curl);
+        outfile.close();
+        return res;
+      }
+    }
+
+    json download_json(std::string url) {
+
+      CURL *curl;
+      CURLcode res;
+
+      std::string json_data;
+
+      curl = curl_easy_init();
+      if (curl) {
+        curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_string);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &json_data);
+
+        res = curl_easy_perform(curl);
+        curl_easy_cleanup(curl);
+      }
+
+      if ((res != CURLE_OK) || (json_data == "")) {
+        std::cout << "Default server unreachable. You may want to specify the --download-url option." << std::endl;
+        return res;
+      }
+
+      return json::parse(json_data);
+    }
+}

--- a/src/io/curl.cxx
+++ b/src/io/curl.cxx
@@ -67,12 +67,17 @@ namespace io {
         curl_easy_cleanup(curl);
       }
 
-      if ((res != CURLE_OK) || (json_string == "")) {
+      if (res != CURLE_OK) {
         std::cout << "Server unreachable. You may want to specify the --download-url option." << std::endl;
         return res;
       }
 
-      json_data = json::parse(json_string);
+      try {
+        json_data = json::parse(json_string);
+      } catch (json::parse_error& ex) {
+        std::cout << "Server response error. You may want to specify the --download-url option." << std::endl;
+        return 1;
+      }
       return 0;
     }
 }

--- a/src/io/curl.cxx
+++ b/src/io/curl.cxx
@@ -50,28 +50,29 @@ namespace io {
       }
     }
 
-    json download_json(std::string url) {
+    int download_json(std::string url, json& json_data) {
 
       CURL *curl;
       CURLcode res;
 
-      std::string json_data;
+      std::string json_string;
 
       curl = curl_easy_init();
       if (curl) {
         curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_string);
-        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &json_data);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &json_string);
 
         res = curl_easy_perform(curl);
         curl_easy_cleanup(curl);
       }
 
-      if ((res != CURLE_OK) || (json_data == "")) {
-        std::cout << "Default server unreachable. You may want to specify the --download-url option." << std::endl;
+      if ((res != CURLE_OK) || (json_string == "")) {
+        std::cout << "Server unreachable. You may want to specify the --download-url option." << std::endl;
         return res;
       }
 
-      return json::parse(json_data);
+      json_data = json::parse(json_string);
+      return 0;
     }
 }


### PR DESCRIPTION
As per a feature request from Yuri, I've added a guidescan `download` command. By default it inspects the endpoint at `http://guidescan.com:8000/download` (already active) to see what can be downloaded, and provide useful metadata about it.

I've programmed this in terms of downloads being of a `type` (currently `index` or `database`), and then there are `item`s within that type. Addition of more types/items on the server will be picked up automatically. I didn't want to use the term `organism` here in case we want to support more generic downloads in the future.

Here's the command line usage:
```
$ ./guidescan download
Unrecognized type. Specify the type using --type or use "--show type" to see available types.

$ ./guidescan download --show type
Supported types are: database index

$ ./guidescan download --type index
Unrecognized item. Specify the item using --item or use "--show item" to see available items.

$ ./guidescan download --type index --show item
Supported items are:
  ce11 (Nematode) [ size=73MB ]
  dm6 (Fruit Fly) [ size=105MB ]
  hg38 (Human) [ size=2.1GB ]
  mm10 (House Mouse) [ size=1.8GB ]
  mm39 (House Mouse) [ size=1.8GB ]
  rn6 (Norway Rat) [ size=1.8GB ]
  sacCer3 (Baker's Yeast) [ size=9MB ]
  
$ ./guidescan download --type index --item sacCer3
Downloading 56%
```

If we ever have to move servers without modifying the code, the user can override the `--download-url` argument:
```
$ ./guidescan download --type database --show item --download-url guidescan3.com/download
```

The server endpoint returns something like the following: (`url`/`desc` are special in the way they are printed/used, everything else is metadata that we can tweak).
```
{
    "index": {
        "dm6": {
            "url": "https://guidescan.com/indices/dm6.zip",
            "size": "105MB",
            "desc": "Fruit Fly"
        },
        ...
    },
    "database": {
        "mm10_cpf1": {
            "url": "https://guidescan.com/databases/cpf1/mm10.bam.sorted",
            "size": "11.2GB",
            "desc": "House Mouse / CPF1"
        },
        ...
    }
}
```

The default `--download-url` uses port `8000` (`http://guidescan.com:8000/download`). I found that it's not possible for a ReactJS app to return `json` mime-type, so I'm tapping the clojure web backend directly. Perhaps you know of another way to expose this directly from React.