### PR TITLE
Added a workflow to check successful building of guidescan

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,11 +32,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Setup (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libcurl4-openssl-dev
+
       - name: Build
         run: |
           cmake -G "${{ matrix.cmake_generator }}" -S . -B build
           cmake --build build
 
-      - name: Guidescan run
+      - name: Guidescan version
         run: |
-          ./build/bin/guidescan
+          ./build/bin/guidescan --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+name: Main
+
+on:
+  push:
+    branches: [ master, develop** ]
+    tags:
+      - '*'
+  pull_request:
+    branches: [ master, develop** ]
+
+jobs:
+
+  release:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+        include:
+          - os: ubuntu-latest
+            cmake_generator: "Unix Makefiles"
+          - os: macos-latest
+            cmake_generator: "Unix Makefiles"
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build
+        run: |
+          cmake -G "${{ matrix.cmake_generator }}" -S . -B build
+          cmake --build build
+
+      - name: Guidescan run
+        run: |
+          ./build/bin/guidescan


### PR DESCRIPTION
Since `guidescan` now has additional dependencies (`curl` etc), this workflow will simply try to compile `guidescan`, regardless of whether its being release or not.