### PR TITLE
Updated the cmake min. version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
 option(LINK_STATICALLY "Statically link the executable against c++11 standard libary" OFF)
 


### PR DESCRIPTION
Updated the cmake min. version, to allow proper use of <package>_ROOT during cmake config (e.g. on gen-comp2)