### PR TITLE
Bug fix for specificity calculation tweaks introduced in PR 14

### DIFF
--- a/include/genomics/printer.hpp
+++ b/include/genomics/printer.hpp
@@ -119,17 +119,20 @@ namespace genomics {
       uint64_t delim = get_delim(gs);
       std::string offtarget_hex("");
       float cfd_sum = 0.0;
+      bool perfect_match = false;
 
       for (uint64_t i = 0; i < off_targets.size(); i++) {
           std::list<int64_t> v;
 
-          std::shuffle(off_targets[i].begin(), off_targets[i].end(), std::mt19937{std::random_device{}()});
           int64_t n_off_targets = 0;
           for (const auto& t : off_targets[i]) {
               if ((max_off_targets != -1) && (n_off_targets >= max_off_targets))
                   break;
               auto pos = std::get<0>(t);
               auto match = std::get<1>(t);
+
+              if (match.mismatches == 0)
+                perfect_match = true;
 
               coordinates c;
               std::string strand;
@@ -149,6 +152,7 @@ namespace genomics {
       }
 
       float specificity = 0.0;
+      if (!perfect_match) cfd_sum += 1;
       if (cfd_sum > 0) specificity = 1/cfd_sum;
 
       return std::make_tuple(offtarget_hex, specificity);
@@ -230,7 +234,8 @@ namespace genomics {
         const auto& off_target = off_targets[d][i];
         int64_t off_target_abs_coords = std::get<0>(off_target);
         match match = std::get<1>(off_target);
-        perfect_match = match.mismatches == 0;
+        if (match.mismatches == 0)
+          perfect_match = true;
         std::string csvline = get_csv_line(gi, k, start, match, off_target_abs_coords, complete);
         if (csvline != "") {
           off_targets_lines.push_back(csvline);


### PR DESCRIPTION
In PR #14, I introduced a tweak in the way we calculate specificity in the case of no matches at all. This is related to the discussion we had on Slack (where you were seeing discrepancies between your script vs. what `guidescan enumerate` gave you):
```
Ok so the python code is doing (1 / 1 + cfd_sum) in case there are no matches, and 1 / cfd_sum if there is at least one match.
Let me put in the exact same logic in C++
```

During an unrelated investigation this week, I discovered some discrepancies between the specificity values that are written in the case of a `.csv` output vs a `.sam` output, and noticed 2 bugs that I introduced in that PR:
1. `perfect_match = match.mismatches == 0;` is not the correct thing to do, since we want to determine if there is a perfect match or not (and not overwrite that flag in subsequent match comparisons of distance >= 0).
1. The specificity tweak only worked anyway in the case of generating the `.csv` file output, not the `.sam` file. Whatever logic was added to the `.csv` file generation should also have been added to the `.sam` file generation.

This PR fixes both these issues.

It was also getting a bit hairy to debug `.sam` files (by doing a simple `md5sum` on what an expected SAM file is vs. what is generated, for example), because we're doing (only for `.sam` files, not for `.csv` files):

```
std::shuffle(off_targets[i].begin(), off_targets[i].end(), std::mt19937{std::random_device{}()});
```

I've taken off this line so we get deterministic `.sam` files now if the inputs haven't changed. This is helpful for my debugging (especially comparing off-target hex strings to what they should be). If this shuffling was put for some specific reason (or if it should be moved to its own issue/PR), I'm happy to take that off here.