### PR TITLE
Generating correct src tar.gz for subsequent bioconda recipe integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,4 +71,4 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         uses: softprops/action-gh-release@v1
         with:
-          files: osqp-${{env.GUIDESCAN_VERSION}}-src.tar.gz
+          files: guidescan-${{env.GUIDESCAN_VERSION}}-src.tar.gz


### PR DESCRIPTION
We would like `guidescan` installed through `bioconda` to show the correct version on `guidescan --version`. To be able to do this, the version information needs to have been burned into the source archives, which then gets pulled from `bioconda`.

Generating a `guidescan-vX.Y.Z.src.tar.gz` file as we're doing in this workflow should allow us to do this. _This_ is the file that needs to be specified in our bioconda recipe's `meta.yml`, not the github-created `../archive/refs/tags/vX.Y.Z.tar.gz` (which is an archive of the repo at the time of release and does not contain version information).

An early version of this workflow was mistakenly trying to upload an `osqp-..` source gz (because I copied the workflow over from another project), which obviously doesn't exist.

This is particularly important to get right going forward since guidescan-generated BAM files now have guidescan version information burnt into the BAM files.