### PR TITLE
Fix for fewer kmers being generated than are seen in the genome

### DIFF
--- a/scripts/generate_kmers.py
+++ b/scripts/generate_kmers.py
@@ -100,6 +100,7 @@ def find_kmers(pam, k, chrm, forward=True, end=True):
         yield kmer.upper(), position+1
 
 def find_all_kmers(pam, k, chrm, end=True):
+    chrm = str(chrm).upper()
     pam_set = generate_pam_set(pam)
     rev_pam_set = list(map(revcom, pam_set))
 


### PR DESCRIPTION
I noticed that on using `generate_kmers.py` script, I was getting fewer kmers than what I get when I use the (now no longer available) `guidescan kmers` command (which I think was used on the server?). This has to do with the fact that kmers like:
`ccgctgea..` are not being considered, because the script is looking for `CCN..` (uppercase match). This doesn't seem to be the case with `guidescan kmers` command which is looking at the `.dna` file (which I see is entirely in uppercase when its generated).

This seems like a safe fix to me and does solve the problem of missing kmers, though perhaps there are use cases I'm not thinking of?