### PR TITLE
Saving SAM read alignment with match chromosome/position, not the kme…

### DIFF
--- a/include/genomics/process.hpp
+++ b/include/genomics/process.hpp
@@ -120,9 +120,9 @@ namespace genomics {
       output << csv_lines;
       output_mtx.unlock();
     } else {
-      std::string sam_line = genomics::get_sam_line(gi_forward, k, opts.start, opts.max_off_targets, off_targets, complete);
+      std::string sam_lines = genomics::get_sam_lines(gi_forward, k, opts.start, opts.max_off_targets, off_targets, complete);
       output_mtx.lock();
-      output << sam_line << std::endl;
+      output << sam_lines;
       output_mtx.unlock();
     }
   }


### PR DESCRIPTION
Earlier version of `guidescan enumerate --format sam ...` assumed that the kmer chromosome and position can be ascertained directly from the incoming kmer file. While this is reasonable, a lot of times this information is not available beforehand, and blank/dummy values for chromosome/position are filled in only to satisfy `guidescan enumerate`.

In these cases, the output of `guidescan enumerate --format csv ...` is correct since it obtains the match positions directly from the offtargets (including at distance 0), but the output of `guidescan enumerate --format sam ...` is incorrect w.r.t. the reference name and reference position fields in the SAM file (because that information was unavailable to begin with).

This PR fixes this issue by getting that information directly from the off-targets at distance 0.

Note that this means that multiple matches at distance 0 will end up producing multiple lines in the SAM file, with identical off-target hex information. This is already happening in the CSV file generation, so this also makes the behavior consistent.